### PR TITLE
Add Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+# Configuration file for travis-ci.org
+#
+# Travis is a continuous integration service that connects to Github &
+# automatically runs tests when commits are made. To use this on your own
+# branches register at https://travis-ci.org & enable builds for your
+# spacegrids branch.
+#
+# If tests fail you will get an email message as well as a message on any pull
+# requests.
+
+language: python
+
+# Python versions to test
+python:
+    - 2.7
+
+# Install anaconda for quicker dependency installs
+before_install:
+    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+    - bash miniconda.sh -b
+    - export PATH=/home/travis/miniconda/bin:$PATH
+    - conda update --yes conda
+
+# Install dependencies & test data
+install:
+    - mkdir -p $HOME/PROJECTS/my_project
+    - wget http://web.science.unsw.edu.au/~wsijp/code/examples.tar.gz -O - | tar xz -C $HOME/PROJECTS/my_project --strip-components=1
+    - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy matplotlib
+    - pip install .
+    - pip freeze
+
+# Run tests
+script: 
+    - python tests/tests.py

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ### Overview
+[![Build Status](https://travis-ci.org/willo12/spacegrids.svg)](https://travis-ci.org/willo12/spacegrids)
 
 Spacegrid is a single python module containing classes to work with and organise data defined on grids (e.g. climate model and observational). It is a bit like "Numpy with grids". The goal is to provide convenient coordinate, grid and data (field) classes that link together, and have short and intuitive data manipulation expressions. In addition, a small framework for project data management is provided. The module provides informative error messages and warnings, and is documented here and extensively inside the python code. 
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='spacegrids',
 # package_data = {
 # "spacegrids": ['README.rst']
 # },
-      long_description=read('README'),
+      long_description=read('README.rst'),
       url='https://github.com/willo12/spacegrids',
       license = "BSD",
 #      install_requires = ["numpy>=1.6","scipy>=0.10","matplotlib>=1.1"]


### PR DESCRIPTION
Adds a configuration file for the Travis continuous integration service. Travis automatically runs tests whenever changes are made to a Github repository and sends out notifications when they fail. 

To set up the tests register with Travis, you'll then get a list of your Github projects that you can enable tests for. See http://docs.travis-ci.com/user/getting-started for more information
